### PR TITLE
[Thesis] Make use of new TravelTimes object

### DIFF
--- a/src/main/java/com/github/rinde/logistics/pdptw/solver/optaplanner/OptaplannerSolvers.java
+++ b/src/main/java/com/github/rinde/logistics/pdptw/solver/optaplanner/OptaplannerSolvers.java
@@ -174,7 +174,7 @@ public final class OptaplannerSolvers {
     final List<Vehicle> vehicleList = new ArrayList<>();
     for (int i = 0; i < state.getVehicles().size(); i++) {
       final VehicleStateObject vso = state.getVehicles().get(i);
-      final Vehicle vehicle = new Vehicle(vso, i);
+      final Vehicle vehicle = new Vehicle(vso, state.getTravelTimes(), i);
       vehicleList.add(vehicle);
 
       final List<ParcelVisit> visits = new ArrayList<>();

--- a/src/test/java/com/github/rinde/logistics/pdptw/mas/comm/RtSolverBidderTest.java
+++ b/src/test/java/com/github/rinde/logistics/pdptw/mas/comm/RtSolverBidderTest.java
@@ -47,6 +47,7 @@ import com.github.rinde.rinsim.core.model.pdp.PDPModel.VehicleParcelActionInfo;
 import com.github.rinde.rinsim.core.model.pdp.PDPModel.VehicleState;
 import com.github.rinde.rinsim.core.model.pdp.Parcel;
 import com.github.rinde.rinsim.core.model.pdp.VehicleDTO;
+import com.github.rinde.rinsim.core.model.road.TravelTimesTestUtil;
 import com.github.rinde.rinsim.core.model.time.RealtimeClockController;
 import com.github.rinde.rinsim.core.model.time.TimeModel;
 import com.github.rinde.rinsim.event.EventAPI;
@@ -87,6 +88,9 @@ public class RtSolverBidderTest {
     rm = mock(PDPRoadModel.class);
     when(rm.getSpeedUnit()).thenReturn(NonSI.KILOMETERS_PER_HOUR);
     when(rm.getDistanceUnit()).thenReturn(SI.KILOMETER);
+    when(rm.getTravelTimes(SI.MILLI(SI.SECOND))).thenReturn(
+      TravelTimesTestUtil.createDefaultPlaneTravelTimes(new Point(0, 0),
+        new Point(10, 10), SI.MILLI(SI.SECOND), SI.KILOMETER));
 
     pm = mock(PDPModel.class);
     when(pm.getEventAPI()).thenReturn(mock(EventAPI.class));

--- a/src/test/java/com/github/rinde/logistics/pdptw/solver/optaplanner/MoveTest.java
+++ b/src/test/java/com/github/rinde/logistics/pdptw/solver/optaplanner/MoveTest.java
@@ -20,6 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.measure.unit.SI;
+
 import org.junit.Test;
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -30,6 +32,7 @@ import org.optaplanner.core.impl.score.director.incremental.IncrementalScoreDire
 import com.github.rinde.rinsim.central.GlobalStateObjectBuilder;
 import com.github.rinde.rinsim.core.model.pdp.Parcel;
 import com.github.rinde.rinsim.core.model.pdp.VehicleDTO;
+import com.github.rinde.rinsim.core.model.road.TravelTimesTestUtil;
 import com.github.rinde.rinsim.geom.Point;
 import com.google.common.collect.ImmutableList;
 
@@ -492,6 +495,10 @@ public class MoveTest {
         .setRoute(v)
         .build());
     }
+
+    b.setTravelTimes(TravelTimesTestUtil.createDefaultPlaneTravelTimes(
+      new Point(0, 0), new Point(10, 10), SI.MILLI(SI.SECOND), SI.KILOMETER));
+
     return OptaplannerSolvers.convert(b.build());
   }
 


### PR DESCRIPTION
The proposed changes will allow the Vehicle to use the new TravelTimes object found in the GlobalStateObject. Tests have been verified and work with the new changes. Cannot complete a "mvn verify" as the new TravelTimes object hasn't been officially introduced in RinSim.