### PR TITLE
Fixed bug in bidValue when reauctioning

### DIFF
--- a/src/main/java/com/github/rinde/logistics/pdptw/mas/comm/RtSolverBidder.java
+++ b/src/main/java/com/github/rinde/logistics/pdptw/mas/comm/RtSolverBidder.java
@@ -372,7 +372,7 @@ public class RtSolverBidder
         LOGGER.trace("Found most expensive parcel for reauction: {}.", toSwap);
 
         final double bidValue = bidFunction.computeBidValue(currentRoute.size(),
-          lowestCost - baseline);
+                baseline - lowestCost);
         final DoubleBid initialBid =
           DoubleBid.create(state.getTime(), decorator, toSwap, bidValue);
 


### PR DESCRIPTION
De bidValue is inderdaad een bug. De reauction wordt telkens gewonnen door de initialBid. Ik dacht dat het toch werkte omdat de succes-rate op de AuctionPanel meer dan 0% aangaf, maar dat komt dan weer omdat de reauctions die nog bezig zijn als succesvol meegeteld worden. 
De succes-rate van reauctions fixing op de AuctionPanel is iets lastiger, want dan moet je echt een onderscheid maken tussen gewone auctions en reauctions. Het is nu moeilijk te bepalen welke reauctions afgelopen zijn en welke niet. 
En bij het bereken van de succes-rate van de AuctionPanel wordt eerst het aantal reauctions berekent en daarna de failedAuctions en unsuccessfulAuctions van afgetrokken. Maar de failedAuctions kunnen volgens mij ook gewone auctions zijn ipv enkel reauctions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rinde/rinlog/3)
<!-- Reviewable:end -->
